### PR TITLE
Add news monitoring bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 - 💞️ I’m looking to collaborate on ...
 - 📫 How to reach me fatsar@gmail.com
 
+## News Bot
+
+This repository contains `news_bot.py`, a simple script that collects headlines
+from Turkish and English news sites and can email a summary.
+
+### Usage
+
+1. Install dependencies with `pip install -r requirements.txt`.
+2. Run `python news_bot.py --dry-run` to print the collected news.
+3. To send email, define the environment variables `SMTP_SERVER`,
+   `SMTP_USER`, `SMTP_PASSWORD` and `EMAIL_RECIPIENTS` (comma separated).
+
 <!---
 fatsar/fatsar is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 You can click the Preview link to take a look at your changes.

--- a/news_bot.py
+++ b/news_bot.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Simple news bot that fetches headlines from Turkish and English news sites
+and optionally emails the summary."""
+
+import argparse
+import os
+import smtplib
+from email.message import EmailMessage
+
+import feedparser
+
+USER_AGENT = "Mozilla/5.0 (news bot)"
+
+NEWS_SOURCES = {
+    "tr": [
+        ("Internethaber", "https://www.internethaber.com/rss"),
+        ("BloombergHT", "https://www.bloomberght.com/rss"),
+    ],
+    "en": [
+        ("Reuters", "https://www.reuters.com/rssFeed/worldNews"),
+        ("Al Jazeera", "https://www.aljazeera.com/xml/rss/all.xml"),
+    ],
+}
+
+
+def fetch_feed(name: str, url: str, max_items: int):
+    """Fetch up to ``max_items`` entries from ``url``.
+
+    Returns a tuple of source name and a list of formatted entries.
+    """
+    try:
+        feed = feedparser.parse(url, agent=USER_AGENT)
+    except Exception as exc:  # pragma: no cover - network failures
+        return name, [f"Error fetching feed: {exc}"]
+
+    entries = []
+    for entry in feed.entries[:max_items]:
+        title = entry.get("title", "No title")
+        link = entry.get("link", "")
+        entries.append(f"- {title}\n  {link}")
+
+    if not entries:
+        entries.append("(no entries found)")
+    return name, entries
+
+
+def collect_news(max_per_source: int = 5) -> str:
+    """Collect news from all configured sources."""
+    sections = []
+    for sources in NEWS_SOURCES.values():
+        for name, url in sources:
+            source_name, items = fetch_feed(name, url, max_per_source)
+            sections.append(f"{source_name}:\n" + "\n".join(items))
+    return "\n\n".join(sections)
+
+
+def send_email(subject: str, body: str, smtp_server: str, smtp_port: int,
+               username: str, password: str, recipients):
+    """Send ``body`` as an email to ``recipients``."""
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = username
+    msg["To"] = ", ".join(recipients)
+    msg.set_content(body)
+
+    with smtplib.SMTP_SSL(smtp_server, smtp_port) as smtp:
+        smtp.login(username, password)
+        smtp.send_message(msg)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fetch news and optionally email them.")
+    parser.add_argument("--max-per-source", type=int, default=5,
+                        help="Maximum number of headlines per source")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print news instead of sending email")
+    args = parser.parse_args()
+
+    news_body = collect_news(args.max_per_source)
+
+    if args.dry_run:
+        print(news_body)
+        return
+
+    smtp_server = os.environ["SMTP_SERVER"]
+    smtp_port = int(os.environ.get("SMTP_PORT", 465))
+    smtp_user = os.environ["SMTP_USER"]
+    smtp_password = os.environ["SMTP_PASSWORD"]
+    recipients = [r.strip() for r in os.environ["EMAIL_RECIPIENTS"].split(",")]
+
+    send_email("Güncel Haberler / Latest News", news_body, smtp_server,
+               smtp_port, smtp_user, smtp_password, recipients)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+feedparser


### PR DESCRIPTION
## Summary
- add `news_bot.py` to gather headlines from Turkish and English sources and email a summary
- document usage and requirements

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile news_bot.py`
- `python news_bot.py --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68c119e70efc8324ab6042e97a9fe669