### PR TITLE
Add hourly refreshing news summary site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,39 @@
-- 👋 Hi, I’m @fatsar
-- 👀 I’m interested in programming
-- 🌱 I’m currently learning Python
-- 💞️ I’m looking to collaborate on ...
-- 📫 How to reach me fatsar@gmail.com
+# Saatlik Haber Özeti Uygulaması
 
-<!---
-fatsar/fatsar is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+Bu proje, farklı haber kaynaklarından RSS akışlarını toplayarak her saat otomatik olarak özetleyen basit bir Flask uygulamasıdır. Uygulama, özetleri web arayüzünde listeler ve gerekirse manuel olarak da yenilenebilir.
+
+## Özellikler
+
+- BBC, Reuters ve Al Jazeera RSS akışlarından haber başlıkları ve özetleri.
+- Saatlik otomatik yenileme (APScheduler ile arka planda).
+- Web arayüzünden anlık yenileme butonu ve otomatik yenilemeyi açıp kapama.
+- JSON formatında haberleri sunan `/api/articles` uç noktası.
+
+## Kurulum
+
+1. Python 3.11 veya üstü bir sürüm kurulu olmalıdır.
+2. Gerekli bağımlılıkları yükleyin:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Uygulamayı başlatın:
+
+   ```bash
+   flask --app app run
+   ```
+
+   veya doğrudan Python ile:
+
+   ```bash
+   python app.py
+   ```
+
+4. Tarayıcınızdan `http://127.0.0.1:5000` adresine giderek uygulamayı görüntüleyebilirsiniz.
+
+## Notlar
+
+- İlk açılışta veriler otomatik olarak yüklenir.
+- Haber özetleri, RSS akışlarının sağladığı özet/description alanından alınır ve 200 karaktere kadar kısaltılır.
+- Yeni kaynaklar eklemek için `app.py` içindeki `NEWS_SOURCES` sözlüğüne yeni bir başlık ve RSS URL'si ekleyebilirsiniz.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,119 @@
+import logging
+import threading
+from datetime import datetime, timezone
+from typing import List, Dict
+
+import feedparser
+from apscheduler.schedulers.background import BackgroundScheduler
+from flask import Flask, render_template, jsonify
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = Flask(__name__)
+
+NEWS_SOURCES = {
+    "BBC": "http://feeds.bbci.co.uk/news/rss.xml",
+    "Reuters": "http://feeds.reuters.com/reuters/topNews",
+    "Al Jazeera": "https://www.aljazeera.com/xml/rss/all.xml",
+}
+
+_refresh_lock = threading.Lock()
+_latest_articles: List[Dict[str, str]] = []
+_last_updated: datetime | None = None
+
+
+def summarise_text(text: str, max_length: int = 200) -> str:
+    if not text:
+        return ""
+    text = " ".join(text.split())
+    if len(text) <= max_length:
+        return text
+    cutoff = text.rfind(" ", 0, max_length)
+    if cutoff == -1:
+        cutoff = max_length
+    return text[:cutoff].rstrip() + "…"
+
+
+def fetch_news() -> None:
+    global _latest_articles, _last_updated
+    logger.info("Fetching latest news items")
+    articles: List[Dict[str, str]] = []
+    for source, url in NEWS_SOURCES.items():
+        try:
+            feed = feedparser.parse(url)
+        except Exception as exc:
+            logger.exception("Failed to parse feed %s: %s", source, exc)
+            continue
+        for entry in feed.entries[:5]:
+            summary = summarise_text(getattr(entry, "summary", "") or getattr(entry, "description", ""))
+            published = getattr(entry, "published", "")
+            link = getattr(entry, "link", "")
+            title = getattr(entry, "title", "Unnamed article")
+            articles.append(
+                {
+                    "source": source,
+                    "title": title,
+                    "summary": summary,
+                    "link": link,
+                    "published": published,
+                }
+            )
+    with _refresh_lock:
+        _latest_articles = articles
+        _last_updated = datetime.now(timezone.utc)
+    logger.info("News refresh completed with %d articles", len(articles))
+
+
+def ensure_data_loaded() -> None:
+    with _refresh_lock:
+        needs_refresh = not _latest_articles
+    if needs_refresh:
+        fetch_news()
+
+
+@app.route("/")
+def index():
+    ensure_data_loaded()
+    with _refresh_lock:
+        articles = list(_latest_articles)
+        last_updated = _last_updated
+    return render_template("index.html", articles=articles, last_updated=last_updated)
+
+
+@app.route("/api/articles")
+def articles_api():
+    ensure_data_loaded()
+    with _refresh_lock:
+        data = {
+            "articles": list(_latest_articles),
+            "last_updated": _last_updated.isoformat() if _last_updated else None,
+        }
+    return jsonify(data)
+
+
+@app.route("/refresh", methods=["POST"])
+def trigger_refresh():
+    fetch_news()
+    return ("", 204)
+
+
+def start_scheduler() -> BackgroundScheduler:
+    scheduler = BackgroundScheduler()
+    scheduler.add_job(fetch_news, "interval", hours=1, id="fetch_news", replace_existing=True)
+    scheduler.start()
+    return scheduler
+
+
+scheduler = start_scheduler()
+
+
+@app.teardown_appcontext
+def shutdown_scheduler(exception=None):
+    if scheduler.running:
+        scheduler.shutdown()
+
+
+if __name__ == "__main__":
+    fetch_news()
+    app.run(host="0.0.0.0", port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask==3.0.3
+feedparser==6.0.11
+APScheduler==3.10.4

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,15 @@
+body {
+  background-color: #f3f4f6;
+}
+
+.card-title {
+  color: #0d6efd;
+}
+
+.navbar {
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.1);
+}
+
+#refreshButton[disabled] {
+  cursor: wait;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<html lang="tr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Haber Özeti Panosu</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous" />
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
+  </head>
+  <body>
+    <nav class="navbar navbar-dark bg-dark mb-4">
+      <div class="container">
+        <span class="navbar-brand mb-0 h1">Saatlik Haber Özeti</span>
+        <button id="refreshButton" class="btn btn-outline-light" type="button">Şimdi Güncelle</button>
+      </div>
+    </nav>
+
+    <main class="container">
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <div>
+          <h1 class="h3 mb-0">Son Haberler</h1>
+          {% if last_updated %}
+          <small class="text-muted">Son güncelleme: {{ last_updated.astimezone().strftime('%d %B %Y %H:%M') }} </small>
+          {% endif %}
+        </div>
+        <div class="form-check form-switch">
+          <input class="form-check-input" type="checkbox" role="switch" id="autoRefresh" checked />
+          <label class="form-check-label" for="autoRefresh">Otomatik yenile</label>
+        </div>
+      </div>
+
+      <div id="articles" class="row g-4">
+        {% for article in articles %}
+        <div class="col-md-6">
+          <article class="card h-100 shadow-sm">
+            <div class="card-body d-flex flex-column">
+              <h2 class="h5 card-title">{{ article.title }}</h2>
+              <h3 class="h6 text-muted">{{ article.source }}</h3>
+              <p class="card-text flex-grow-1">{{ article.summary or 'Özet mevcut değil.' }}</p>
+              <div class="mt-3 d-flex justify-content-between align-items-center">
+                <small class="text-secondary">{{ article.published }}</small>
+                <a href="{{ article.link }}" class="btn btn-primary btn-sm" target="_blank" rel="noopener">Habere git</a>
+              </div>
+            </div>
+          </article>
+        </div>
+        {% else %}
+        <div class="col-12 text-center text-muted">
+          Şu anda görüntülenecek haber bulunamadı.
+        </div>
+        {% endfor %}
+      </div>
+    </main>
+
+    <script>
+      async function loadArticles() {
+        const response = await fetch('/api/articles');
+        if (!response.ok) {
+          throw new Error('Veri alınamadı');
+        }
+        return response.json();
+      }
+
+      function formatDate(isoString) {
+        if (!isoString) {
+          return '';
+        }
+        const date = new Date(isoString);
+        return date.toLocaleString('tr-TR', {
+          day: '2-digit',
+          month: 'long',
+          year: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
+        });
+      }
+
+      function renderArticles(data) {
+        const container = document.getElementById('articles');
+        const articles = data.articles || [];
+        container.innerHTML = '';
+
+        if (!articles.length) {
+          container.innerHTML = '<div class="col-12 text-center text-muted">Şu anda görüntülenecek haber bulunamadı.</div>';
+          return;
+        }
+
+        for (const article of articles) {
+          const column = document.createElement('div');
+          column.className = 'col-md-6';
+          column.innerHTML = `
+            <article class="card h-100 shadow-sm">
+              <div class="card-body d-flex flex-column">
+                <h2 class="h5 card-title">${article.title}</h2>
+                <h3 class="h6 text-muted">${article.source}</h3>
+                <p class="card-text flex-grow-1">${article.summary || 'Özet mevcut değil.'}</p>
+                <div class="mt-3 d-flex justify-content-between align-items-center">
+                  <small class="text-secondary">${article.published || ''}</small>
+                  <a href="${article.link}" class="btn btn-primary btn-sm" target="_blank" rel="noopener">Habere git</a>
+                </div>
+              </div>
+            </article>`;
+          container.appendChild(column);
+        }
+
+        const subtitle = document.querySelector('small.text-muted');
+        if (subtitle) {
+          subtitle.textContent = `Son güncelleme: ${formatDate(data.last_updated)}`;
+        }
+      }
+
+      async function refreshArticles() {
+        try {
+          const data = await loadArticles();
+          renderArticles(data);
+        } catch (error) {
+          console.error(error);
+        }
+      }
+
+      document.getElementById('refreshButton').addEventListener('click', async () => {
+        const button = document.getElementById('refreshButton');
+        button.disabled = true;
+        await fetch('/refresh', { method: 'POST' });
+        await refreshArticles();
+        button.disabled = false;
+      });
+
+      const autoRefreshToggle = document.getElementById('autoRefresh');
+      let intervalId = setInterval(refreshArticles, 60 * 60 * 1000);
+
+      autoRefreshToggle.addEventListener('change', (event) => {
+        if (event.target.checked) {
+          refreshArticles();
+          intervalId = setInterval(refreshArticles, 60 * 60 * 1000);
+        } else {
+          clearInterval(intervalId);
+        }
+      });
+
+      refreshArticles();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- replace the placeholder profile README with setup instructions for a news summary dashboard
- build a Flask application that aggregates RSS feeds and refreshes them hourly with APScheduler
- add a Bootstrap-based interface with manual refresh controls and JSON API endpoint

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68cbb2b569188324a96cf65c2acab6ba