### PR TITLE
Add mobile-first public restroom finder (geolocation + Overpass API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-- 👋 Hi, I’m @fatsar
-- 👀 I’m interested in programming
-- 🌱 I’m currently learning Python
-- 💞️ I’m looking to collaborate on ...
-- 📫 How to reach me fatsar@gmail.com
+# Public Restroom Finder
 
-<!---
-fatsar/fatsar is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+A mobile-first single-page site that shows the closest public restrooms (WC) near your current location. It uses your device location and OpenStreetMap data via the Overpass API to list nearby restrooms and their distance.
+
+## How to run
+
+Open `index.html` directly in a browser, or serve the folder with a local web server:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then visit `http://localhost:8000` on your phone or in a mobile emulator and tap **Use my location**.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,146 @@
+const locateButton = document.getElementById("locate");
+const statusText = document.getElementById("status");
+const resultsList = document.getElementById("results");
+const radiusInput = document.getElementById("radius");
+const radiusValue = document.getElementById("radius-value");
+
+const formatDistance = (meters) => {
+  if (meters < 1000) {
+    return `${Math.round(meters)} m`;
+  }
+  return `${(meters / 1000).toFixed(2)} km`;
+};
+
+const toRadians = (value) => (value * Math.PI) / 180;
+
+const getDistanceMeters = (origin, destination) => {
+  const earthRadius = 6371e3;
+  const lat1 = toRadians(origin.lat);
+  const lat2 = toRadians(destination.lat);
+  const deltaLat = toRadians(destination.lat - origin.lat);
+  const deltaLon = toRadians(destination.lon - origin.lon);
+
+  const a =
+    Math.sin(deltaLat / 2) * Math.sin(deltaLat / 2) +
+    Math.cos(lat1) * Math.cos(lat2) *
+    Math.sin(deltaLon / 2) * Math.sin(deltaLon / 2);
+
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return earthRadius * c;
+};
+
+const updateStatus = (message) => {
+  statusText.textContent = message;
+};
+
+const updateRadiusValue = () => {
+  radiusValue.textContent = `${radiusInput.value} m`;
+};
+
+const buildOverpassQuery = (lat, lon, radius) => `
+  [out:json];
+  (
+    node["amenity"="toilets"](around:${radius},${lat},${lon});
+    way["amenity"="toilets"](around:${radius},${lat},${lon});
+    relation["amenity"="toilets"](around:${radius},${lat},${lon});
+  );
+  out center tags;
+`;
+
+const renderResults = (restrooms) => {
+  resultsList.innerHTML = "";
+
+  if (restrooms.length === 0) {
+    resultsList.innerHTML = "<li class=\"result\">No public restrooms found in this area.</li>";
+    return;
+  }
+
+  restrooms.forEach((restroom) => {
+    const item = document.createElement("li");
+    item.className = "result";
+
+    const title = document.createElement("h3");
+    title.textContent = restroom.name || "Public restroom";
+
+    const address = document.createElement("p");
+    address.textContent = restroom.address || "Address not listed";
+
+    const meta = document.createElement("p");
+    meta.className = "result__meta";
+    meta.textContent = `${formatDistance(restroom.distance)} • ${restroom.access}`;
+
+    item.append(title, address, meta);
+    resultsList.appendChild(item);
+  });
+};
+
+const fetchRestrooms = async (position) => {
+  const { latitude, longitude } = position.coords;
+  const radius = Number(radiusInput.value);
+
+  updateStatus("Searching for nearby restrooms...");
+  resultsList.innerHTML = "";
+
+  const response = await fetch("https://overpass-api.de/api/interpreter", {
+    method: "POST",
+    body: buildOverpassQuery(latitude, longitude, radius),
+  });
+
+  if (!response.ok) {
+    updateStatus("Unable to reach the restroom data source. Please try again.");
+    return;
+  }
+
+  const data = await response.json();
+  const origin = { lat: latitude, lon: longitude };
+
+  const restrooms = data.elements
+    .map((element) => {
+      const coords = element.type === "node"
+        ? { lat: element.lat, lon: element.lon }
+        : { lat: element.center?.lat, lon: element.center?.lon };
+
+      if (!coords.lat || !coords.lon) {
+        return null;
+      }
+
+      const tags = element.tags || {};
+      const addressParts = [
+        tags["addr:housenumber"],
+        tags["addr:street"],
+        tags["addr:city"],
+      ].filter(Boolean);
+
+      return {
+        name: tags.name,
+        address: addressParts.length ? addressParts.join(" ") : tags.description,
+        access: tags.access === "yes" ? "Public access" : tags.access === "customers" ? "Customers only" : "Access unknown",
+        distance: getDistanceMeters(origin, coords),
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.distance - b.distance);
+
+  updateStatus(`Found ${restrooms.length} restroom${restrooms.length === 1 ? "" : "s"} nearby.`);
+  renderResults(restrooms);
+};
+
+const handleLocationError = (error) => {
+  let message = "Location access failed. Please allow location permissions.";
+  if (error.code === error.TIMEOUT) {
+    message = "Location request timed out. Please try again.";
+  }
+  updateStatus(message);
+};
+
+locateButton.addEventListener("click", () => {
+  updateStatus("Requesting your location...");
+  navigator.geolocation.getCurrentPosition(fetchRestrooms, handleLocationError, {
+    enableHighAccuracy: true,
+    timeout: 10000,
+  });
+});
+
+radiusInput.addEventListener("input", updateRadiusValue);
+
+updateRadiusValue();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Nearby Public Restrooms</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="app__header">
+        <p class="app__eyebrow">Closest public restrooms</p>
+        <h1>Find a restroom near you</h1>
+        <p class="app__subtitle">
+          Use your current location to locate public restrooms (WC) within walking distance.
+        </p>
+      </header>
+
+      <section class="app__controls" aria-label="Search controls">
+        <div class="control">
+          <label for="radius">Search radius</label>
+          <div class="control__row">
+            <input id="radius" type="range" min="250" max="2500" step="250" value="1000" />
+            <span id="radius-value">1000 m</span>
+          </div>
+        </div>
+        <button id="locate" class="button">Use my location</button>
+      </section>
+
+      <section class="app__status" aria-live="polite">
+        <p id="status">Tap “Use my location” to get started.</p>
+      </section>
+
+      <section class="app__results" aria-label="Restroom results">
+        <ul id="results" class="results" role="list"></ul>
+      </section>
+
+      <footer class="app__footer">
+        <p>
+          Data from OpenStreetMap contributors. Results depend on community-supplied data.
+        </p>
+      </footer>
+    </main>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,138 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  background: #f5f6fa;
+  color: #1f2532;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 24px 16px 40px;
+}
+
+.app {
+  max-width: 520px;
+  margin: 0 auto;
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 24px 20px 32px;
+  box-shadow: 0 12px 40px rgba(16, 24, 40, 0.08);
+}
+
+.app__header h1 {
+  font-size: 1.8rem;
+  margin: 8px 0 6px;
+}
+
+.app__eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.15em;
+  color: #6d7688;
+  margin: 0;
+}
+
+.app__subtitle {
+  margin: 0 0 16px;
+  color: #465065;
+  line-height: 1.5;
+}
+
+.app__controls {
+  display: grid;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.control label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.control__row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.control input[type="range"] {
+  flex: 1;
+}
+
+.button {
+  border: none;
+  border-radius: 999px;
+  padding: 14px 18px;
+  font-weight: 600;
+  background: #2f6bff;
+  color: #fff;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.button:active {
+  transform: scale(0.98);
+}
+
+.app__status {
+  background: #f0f4ff;
+  border-radius: 16px;
+  padding: 12px 14px;
+  color: #2a3e79;
+  margin-bottom: 16px;
+}
+
+.results {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.result {
+  border-radius: 16px;
+  padding: 14px 16px;
+  border: 1px solid #e6eaf2;
+  background: #fbfbfd;
+}
+
+.result h3 {
+  margin: 0 0 6px;
+  font-size: 1rem;
+}
+
+.result p {
+  margin: 0;
+  color: #4e586e;
+  font-size: 0.95rem;
+}
+
+.result__meta {
+  margin-top: 8px;
+  font-size: 0.85rem;
+  color: #6c7485;
+}
+
+.app__footer {
+  margin-top: 24px;
+  font-size: 0.8rem;
+  color: #7a8294;
+  text-align: center;
+}
+
+@media (min-width: 640px) {
+  body {
+    padding: 40px 24px 48px;
+  }
+
+  .app {
+    padding: 32px 28px 40px;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight mobile-first single-page site that finds the closest public restrooms (WC) using the device's location and community OpenStreetMap data.
- Give users a simple control to set search radius and quick, distance-sorted results suitable for on-the-go use.

### Description
- Add `index.html` which implements the mobile-first layout, search controls, status region, and result list.
- Add `styles.css` which contains responsive styling for the app container, controls, buttons, and result cards.
- Add `app.js` which implements geolocation, builds an Overpass API query, computes Haversine distances, sorts results by proximity, and renders access/address metadata.
- Update `README.md` with instructions to run the site locally and how to use the app.

### Testing
- Launched a local server with `python3 -m http.server 8000` and verified the page loaded in a headless browser using Playwright, producing a screenshot at `artifacts/restroom-finder.png`, and the check succeeded.
- No unit or integration tests were added and no automated Overpass API integration tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69889867e5b08324a0520d3cbaad5add)